### PR TITLE
LauncherInjector

### DIFF
--- a/DX11-Base.sln
+++ b/DX11-Base.sln
@@ -7,6 +7,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NetCrack-PalWorld", "DX11-B
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PalworldSDK", "libs\SDKLibrary\PalworldSDK.vcxproj", "{202F0C63-0183-4CE5-AAB4-4ABD2EA773D9}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PalLauncher", "libs\Launcher\PalLauncher.vcxproj", "{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -31,6 +33,14 @@ Global
 		{202F0C63-0183-4CE5-AAB4-4ABD2EA773D9}.Release|x64.Build.0 = Release|x64
 		{202F0C63-0183-4CE5-AAB4-4ABD2EA773D9}.Release|x86.ActiveCfg = Release|Win32
 		{202F0C63-0183-4CE5-AAB4-4ABD2EA773D9}.Release|x86.Build.0 = Release|Win32
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Debug|x64.ActiveCfg = Debug|x64
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Debug|x64.Build.0 = Debug|x64
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Debug|x86.ActiveCfg = Debug|Win32
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Debug|x86.Build.0 = Debug|Win32
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Release|x64.ActiveCfg = Release|x64
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Release|x64.Build.0 = Release|x64
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Release|x86.ActiveCfg = Release|Win32
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DX11-Base.vcxproj
+++ b/DX11-Base.vcxproj
@@ -44,12 +44,14 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -80,11 +82,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)\bin</OutDir>
-    <TargetName>$(ProjectName)_debug</TargetName>
+    <TargetName>palcrackd</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)\bin</OutDir>
+    <TargetName>palcrack</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -179,6 +182,7 @@
     <ClInclude Include="include\helper.h" />
     <ClInclude Include="include\Hooking.hpp" />
     <ClInclude Include="include\Menu.hpp" />
+    <ClInclude Include="initialize.hpp" />
     <ClInclude Include="ItemList.hpp" />
     <ClInclude Include="libs\ImGui\imconfig.h" />
     <ClInclude Include="libs\ImGui\imgui.h" />

--- a/libs/Launcher/Launcher.cpp
+++ b/libs/Launcher/Launcher.cpp
@@ -1,0 +1,102 @@
+#include "pch.h"
+#include "Launcher.h"
+
+
+int ExitWithErrorMsg(const char* eMSG, DWORD eCODE)
+{
+	LPSTR messageBuffer = nullptr;
+	size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, eCODE, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+	std::string errorMsg(messageBuffer, size);
+	LocalFree(messageBuffer);
+
+	char buf[0x512];
+	sprintf_s(buf, "Palworld Launcher encountered an error and will now exit.\n\nMSG: %s\nSRC: %s", errorMsg.c_str(), eMSG);
+	MessageBoxA(nullptr, buf, "Palworld Launcher Fatal Error", MB_ICONWARNING);
+	free(buf);
+	return EXIT_FAILURE;
+}
+
+std::string GetCurrentPath()
+{
+	char buffer[MAX_PATH] = { 0 };
+	GetModuleFileNameA(NULL, buffer, MAX_PATH);
+	std::string::size_type pos = std::string(buffer).find_last_of("\\/");
+	return std::string(buffer).substr(0, pos);
+}
+
+bool IsGameRunning(const wchar_t* procName, DWORD* dwPID)
+{
+	HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+	if (hSnap == INVALID_HANDLE_VALUE)
+		return false;
+
+	PROCESSENTRY32 pe32;
+	pe32.dwSize = sizeof(pe32);
+	if (!Process32First(hSnap, &pe32))
+	{
+		CloseHandle(hSnap);
+		return false;
+	}
+
+	do
+	{
+		if (_wcsicmp(pe32.szExeFile, procName))
+			continue;
+
+		*dwPID = pe32.th32ProcessID;
+		CloseHandle(hSnap);
+		return true;
+
+	} while (Process32Next(hSnap, &pe32));
+	
+	CloseHandle(hSnap);
+	return false;
+}
+
+bool Inject(HANDLE hProc)
+{
+	void* addr = VirtualAllocEx(hProc, NULL, MAX_PATH, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+	if (!addr)
+		return false;
+
+	std::string path = GetCurrentPath() + "\\" + DLL_NAME;
+	if (!WriteProcessMemory(hProc, addr, path.c_str(), strlen(path.c_str()) + 1, NULL))
+	{
+		VirtualFreeEx(hProc, addr, 0, MEM_RELEASE);
+		CloseHandle(hProc);
+		return false;
+	}
+
+	HANDLE hThread = CreateRemoteThread(hProc, 0, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(LoadLibraryA), addr, 0, 0);
+	if (!hThread)
+	{
+		VirtualFreeEx(hProc, addr, 0, MEM_RELEASE);
+		CloseHandle(hProc);
+		return false;
+	}
+}
+
+
+//	main function
+int exec()
+{
+	__int8 rTick = 0;
+	DWORD procID;
+	while (!IsGameRunning(PROCESS_NAME, &procID))
+	{
+		Sleep(1000);
+		rTick++;
+
+		if (rTick >= 10)
+			return ExitWithErrorMsg("", 3);
+	}
+
+	HANDLE hProc = OpenProcess(PROCESS_ALL_ACCESS, false, procID);
+	if (!hProc)
+		return ExitWithErrorMsg("", GetLastError());
+
+	if (!Inject(hProc))
+		return ExitWithErrorMsg("", GetLastError());
+
+	return 0;
+}

--- a/libs/Launcher/Launcher.h
+++ b/libs/Launcher/Launcher.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "pch.h"
+
+static const wchar_t* PROCESS_NAME = (isXbox) ? L"Palworld-WinGDK-Shipping.exe" : L"Palworld-Win64-Shipping.exe";
+static const char* DLL_NAME = (isDebug) ? "palcrackd.dll" : "palcrack.dll";
+
+int ExitWithErrorMsg(const char* eMSG, DWORD eCODE);
+std::string GetCurrentPath();
+bool IsGameRunning(const wchar_t* procName, DWORD* dwPID);
+int exec();

--- a/libs/Launcher/PalLauncher.sln
+++ b/libs/Launcher/PalLauncher.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.33529.622
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PalLauncher", "PalLauncher.vcxproj", "{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Debug|x64.ActiveCfg = Debug|x64
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Debug|x64.Build.0 = Debug|x64
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Debug|x86.ActiveCfg = Debug|Win32
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Debug|x86.Build.0 = Debug|Win32
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Release|x64.ActiveCfg = Release|x64
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Release|x64.Build.0 = Release|x64
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Release|x86.ActiveCfg = Release|Win32
+		{D2AD484E-A628-4BAD-9AF0-904DBB5A23F7}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {25C1493A-5BD7-4E6C-B597-F052D1D93442}
+	EndGlobalSection
+EndGlobal

--- a/libs/Launcher/PalLauncher.vcxproj
+++ b/libs/Launcher/PalLauncher.vcxproj
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{d2ad484e-a628-4bad-9af0-904dbb5a23f7}</ProjectGuid>
+    <RootNamespace>PalLauncher</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)\bin</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)\bin</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <ClCompile Include="Launcher.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Launcher.h" />
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/libs/Launcher/PalLauncher.vcxproj.filters
+++ b/libs/Launcher/PalLauncher.vcxproj.filters
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Launcher.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Launcher.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/libs/Launcher/main.cpp
+++ b/libs/Launcher/main.cpp
@@ -1,0 +1,11 @@
+#include "pch.h"
+#include "Launcher.h"
+
+int wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR cmdLine, int cmdShow)
+{
+	UNREFERENCED_PARAMETER(hInstance);
+	UNREFERENCED_PARAMETER(hPrevInstance);
+	UNREFERENCED_PARAMETER(cmdLine);
+	UNREFERENCED_PARAMETER(cmdShow);
+	return exec();
+}

--- a/libs/Launcher/pch.cpp
+++ b/libs/Launcher/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/libs/Launcher/pch.h
+++ b/libs/Launcher/pch.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <Windows.h>
+#include <TlHelp32.h>
+#include <iostream>
+
+#ifndef _DEBUG
+#define _DEBUG false
+#else
+#error "ERROR: DEBUG BUILDS NOT REQUIRED"
+#endif
+
+
+
+#ifndef XBOX_VER
+#define XBOX_VER false
+#endif
+
+#if XBOX_VER
+#pragma message("ATTENTION: XBOX MODULE NOT YET IMPLEMENTED")
+#endif
+constexpr bool isDebug = _DEBUG;
+constexpr bool isXbox = XBOX_VER;

--- a/src/Hooking.cpp
+++ b/src/Hooking.cpp
@@ -17,13 +17,12 @@ namespace DX11_Base {
 
 	void Hooking::Hook()
 	{
-		//������ע��HOOK
 		g_GameVariables->Init();
 		g_D3D11Window->Hook();
 		Config.Init();
 		MH_EnableHook(MH_ALL_HOOKS);
 #if DEBUG
-		g_Console->printdbg("Hooking::Hook Initialized\n", Console::Colors::pink);
+		g_Console->printdbg("Hooking::Hook Initialized\n", Console::Colors::green);
 #endif
 		return;
 	}


### PR DESCRIPTION
### CHANGES
- Launcher / Injector  

Make sure Palworld is running then launch `PalworldLauncher.exe`
**NOTE**: To utilize launcher `palcrack.dll` must be in the same directory as `PalLauncher.exe`.  

### OPTIONS
**XBOX**: Setting this to true will have the launcher search for xbox version of palworld for injection

https://github.com/NightFyre/Palworld-Internal/blob/cc6c57120a4cedb0ba69a1b91039b831770055b3/libs/Launcher/pch.h#L15
