### PR TITLE
Fix Debugging Console Color Support

### DIFF
--- a/src/Console.cpp
+++ b/src/Console.cpp
@@ -32,12 +32,12 @@ namespace DX11_Base
 	//	raw print to console with desired color and formatting
 	void Console::printdbg(const char* Text, Colors color, ...)
 	{
-		SetConsoleTextAttribute(this->pHwnd, color);
+		SetConsoleTextAttribute(this->pHandle, color);
 		va_list arg;
 		va_start(arg, color);
 		vfprintf(this->stream_out, Text, arg);
 		va_end(arg);
-		SetConsoleTextAttribute(this->pHwnd, Colors::DEFAULT);
+		SetConsoleTextAttribute(this->pHandle, Colors::DEFAULT);
 	}
 
 	//	console take input from user 


### PR DESCRIPTION
current behavior: `SetConsoleTextAttribute` not works, failed to set color
fixed:  works, now text with color

The handle passed to `SetConsoleTextAttribute` should be the device handle instead of the window handle.

Introduced here:

[commit diff](https://github.com/NightFyre/Palworld-Internal/commit/bf219737f875e81991b8edb3bcaf72e3b9430ac5#diff-a634b4e07e53e7e10f7ead96fd4dd710650abbdebc031bd6c10ee1004d1d48a9)